### PR TITLE
Update `peft` in order to be compatible with the latest `diffusers` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "diffusers @ git+https://github.com/huggingface/diffusers.git",
   "imageio-ffmpeg~=0.6.0",
   "imageio~=2.37",
-  "peft~=0.14.0",
+  "peft>=0.14.0",
   "pydantic~=2.10",
   "sentencepiece==0.2.0",
   "transformers~=4.49",


### PR DESCRIPTION
The latest `diffusers` version uses `peft>=0.15.0`, which is shown in this [commit](https://github.com/huggingface/diffusers/commit/53f1043cbb5c41a186b56092dded57166200b520). However, CogKit [uses](https://github.com/THUDM/CogKit/blob/main/pyproject.toml#L17) `peft~=0.14.0`. 
Because of this, when trying to install CogKit, I have encountered the following error:
```
    Updated https://github.com/huggingface/diffusers (8c661ea586bf11cb2440da740dd3c4cf84679b85)
  × No solution found when resolving dependencies:
  ╰─▶ Because only cogkit==0.0.1.dev167 is available and cogkit==0.0.1.dev167 depends on peft>=0.14.0,<0.15.dev0, we can conclude that all versions 
  of cogkit depend on peft>=0.14.0,<0.15.dev0.
      And because your project depends on cogkit and peft>=0.15.2, we can conclude that your project's requirements are unsatisfiable.
```

Thus, we have to allow to use a different `peft` version.  
I updated `pyproject.toml` with a less restricted version of `peft>=0.14.0`.